### PR TITLE
Catch ns-resolve errors

### DIFF
--- a/src/topology/analyzer.clj
+++ b/src/topology/analyzer.clj
@@ -21,12 +21,7 @@
   [ns-str]
   (filter #(= :def (:op %)) (jvm/analyze-ns ns-str)))
 
-(defn ns->edges
-  [ns-str]
-  (mapcat #(edges ns-str %) (ns->defs ns-str)))
-
-;; classpath
-(defn broken-ns->edges [ns-str]
+(defn ns->edges [ns-str]
   (mapcat (fn [[f deps]] (map (fn [x] [f x]) deps))
           (c/filtered (c/all-fq (c/dependencies ns-str)))))
 

--- a/src/topology/clique.clj
+++ b/src/topology/clique.clj
@@ -19,7 +19,10 @@
 (defn fqns
   "Returns the fully qualified namespace of the given symbol s in namespace ns"
   ([ns s]
-   (if-let [rns (-> (ns-resolve ns s) meta :ns)]
+   (if-let [rns (try (-> (ns-resolve ns s) meta :ns)
+                     (catch Exception e
+                       (.println *err* (str "Could not resolve: " ns "/" s))
+                       nil))]
      (symbol (str rns) (name s))
      s)))
 


### PR DESCRIPTION
This allows `lein topology` to be run on itself, so that it doesn't error on trying to resolve the `leiningen.topology/topology.core` (a quoted symbol in leiningen.topology), or quoted symbols in general.
